### PR TITLE
build: add version management via git tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 !/paper.md
 !/README.md
 !/examples/
+!/cmake/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.10..4.1)
-
-project(xcmixin LANGUAGES CXX VERSION 1.0.1)
+include(cmake/get_version.cmake)
+xc_get_project_version(PROJECT_VERSION)
+project(xcmixin LANGUAGES CXX VERSION ${PROJECT_VERSION})
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(GNUInstallDirs)
-option(XCMIXIN_BUILD_EXAMPLES "Build xcmixin examples" ON)
+option(XCMIXIN_BUILD_EXAMPLES "Build xcmixin examples" OFF)
 add_library(xcmixin INTERFACE)
 target_include_directories( xcmixin INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -25,7 +26,7 @@ install(
     EXPORT xcmixin
     NAMESPACE xcmixin::
     FILE xcmixinConfig.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/xcmixin/
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/xcmixin/
 )
 
 install(

--- a/cmake/get_version.cmake
+++ b/cmake/get_version.cmake
@@ -1,0 +1,63 @@
+# Version Management via Git Tags
+#
+# This module provides functions to extract project version from git tags.
+# Version format: vX.Y.Z (e.g., v1.0.0)
+#
+# Usage:
+#   include(cmake/get_version.cmake)
+#   xc_get_project_version(PROJECT_VERSION)
+#
+# Public API:
+#   xc_get_last_git_tag(TAG_VAR DEFAULT_VALUE) - Get the most recent git tag
+#   xc_get_project_version(VERSION_VAR)        - Get version from latest tag
+
+find_program(GII NAMES git)
+
+# xc_get_last_git_tag(TAG_VAR DEFAULT_VALUE)
+# Get the most recent git tag
+#
+# Args:
+#   TAG_VAR     - Variable to store the tag
+#   DEFAULT_VALUE - Default value if no tag found
+#
+# Examples:
+#   xc_get_last_git_tag(TAG "v0.0.0")
+function(xc_get_last_git_tag TAG_VAR DEFAULT_VALUE)
+    if(NOT GII)
+        message(FATAL_ERROR "git not found")
+    endif()
+
+    set(${TAG_VAR} ${DEFAULT_VALUE} PARENT_SCOPE)
+
+    execute_process(
+        COMMAND ${GII} describe --abbrev=0 --tags
+        OUTPUT_VARIABLE GIT_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(GIT_TAG)
+        message(STATUS "GIT_TAG: ${GIT_TAG}")
+        set(${TAG_VAR} ${GIT_TAG} PARENT_SCOPE)
+    endif()
+endfunction(xc_get_last_git_tag)
+
+# xc_get_project_version(VERSION_VAR)
+# Get project version from latest git tag
+#
+# Extracts version in format X.Y.Z from tag (e.g., v1.2.3 -> 1.2.3)
+# Defaults to 0.0.0 if no valid tag found
+#
+# Args:
+#   VERSION_VAR - Variable to store the version
+#
+# Examples:
+#   xc_get_project_version(PROJECT_VERSION)
+function(xc_get_project_version VERSION_VAR)
+    xc_get_last_git_tag(GIT_TAG "v0.0.0")
+    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" VERSION ${GIT_TAG})
+    if(NOT VERSION)
+        message(FATAL_ERROR "git tag ${GIT_TAG} not match version format")
+    endif()
+    set(${VERSION_VAR} ${VERSION} PARENT_SCOPE)
+    message(STATUS "VERSION: ${VERSION}")
+endfunction(xc_get_project_version)


### PR DESCRIPTION
Add cmake/get_version.cmake module to extract project version from git tags (format: vX.Y.Z). Also update CMake configuration:
- Change XCMIXIN_BUILD_EXAMPLES default to OFF
- Fix install destination to standard cmake/xcmixin/ path
- Add cmake/ directory to git tracking