### PR TITLE
docs: update repository URL references

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -1,9 +1,9 @@
 # xcmixin
 
-[![GitHub License](https://img.shields.io/github/license/X-ChenD-Hai/xcmixin)](https://github.com/X-ChenD-Hai/xcmixin/blob/main/LICENSE)
-[![GitHub Release](https://img.shields.io/github/v/release/X-ChenD-Hai/xcmixin)](https://github.com/X-ChenD-Hai/xcmixin/releases)
-[![GitHub Tag](https://img.shields.io/github/v/tag/X-ChenD-Hai/xcmixin)](https://github.com/X-ChenD-Hai/xcmixin/tags)
-![GitHub top language](https://img.shields.io/github/languages/top/X-ChenD-Hai/xcmixin?style=flat)
+[![GitHub License](https://img.shields.io/github/license/xcrtp/xcmixin)](https://github.com/xcrtp/xcmixin/blob/main/LICENSE)
+[![GitHub Release](https://img.shields.io/github/v/release/xcrtp/xcmixin)](https://github.com/xcrtp/xcmixin/releases)
+[![GitHub Tag](https://img.shields.io/github/v/tag/xcrtp/xcmixin)](https://github.com/xcrtp/xcmixin/tags)
+![GitHub top language](https://img.shields.io/github/languages/top/xcrtp/xcmixin?style=flat)
 
 **xcmixin** 是现代 C++ 的静态混入（Mixin）解决方案，通过 CRTP 模式在编译期将多个方法混入类中，无需修改类的原始定义。
 
@@ -310,4 +310,4 @@ MSVC 编译器在处理扩展混入宏时存在重载决议缺陷。当使用 `X
 
 ## 许可证
 
-[MIT License](https://github.com/X-ChenD-Hai/xcmixin/blob/main/LICENSE)
+[MIT License](https://github.com/xcrtp/xcmixin/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # xcmixin
 
-[![GitHub License](https://img.shields.io/github/license/X-ChenD-Hai/xcmixin)](https://github.com/X-ChenD-Hai/xcmixin/blob/main/LICENSE)
-[![GitHub Release](https://img.shields.io/github/v/release/X-ChenD-Hai/xcmixin)](https://github.com/X-ChenD-Hai/xcmixin/releases)
-[![GitHub Tag](https://img.shields.io/github/v/tag/X-ChenD-Hai/xcmixin)](https://github.com/X-ChenD-Hai/xcmixin/tags)
-![GitHub top language](https://img.shields.io/github/languages/top/X-ChenD-Hai/xcmixin?style=flat)
+[![GitHub License](https://img.shields.io/github/license/xcrtp/xcmixin)](https://github.com/xcrtp/xcmixin/blob/main/LICENSE)
+[![GitHub Release](https://img.shields.io/github/v/release/xcrtp/xcmixin)](https://github.com/xcrtp/xcmixin/releases)
+[![GitHub Tag](https://img.shields.io/github/v/tag/xcrtp/xcmixin)](https://github.com/xcrtp/xcmixin/tags)
+![GitHub top language](https://img.shields.io/github/languages/top/xcrtp/xcmixin?style=flat)
 
 
 **xcmixin** is a modern C++ static mixin solution that uses CRTP to compose multiple methods into classes at compile time, without modifying the original class definition.
@@ -311,4 +311,4 @@ See [examples/overload-msvc-bug.cc](examples/overload-msvc-bug.cc) for details.
 
 ## License
 
-[MIT License](https://github.com/X-ChenD-Hai/xcmixin/blob/main/LICENSE)
+[MIT License](https://github.com/xcrtp/xcmixin/blob/main/LICENSE)

--- a/xcmixin/xcmixin.hpp
+++ b/xcmixin/xcmixin.hpp
@@ -4,7 +4,7 @@
 // Copyright (c) 2024 Tian Li
 // Licensed under the MIT License.
 //
-// https://github.com/X-ChenD-Hai/xcmixin
+// https://github.com/xcrtp/xcmixin
 
 #pragma once
 #include <type_traits>


### PR DESCRIPTION
Update GitHub repository links from X-ChenD-Hai to xcrtp across README files and the main header file.