### PR TITLE
fix: run tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,14 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DXCMIXIN_BUILD_EXAMPLES=ON
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DXCMIXIN_BUILD_EXAMPLES=ON -DXCMIXIN_BUILD_TESTS=ON
 
       - name: Build
         run: |
           cmake --build build --parallel
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
 
       - name: Run examples
         run: |


### PR DESCRIPTION
## Summary
- Add test execution step to release workflow
- Enable test build with `-DXCMIXIN_BUILD_TESTS=ON` in CMake configuration

## Test plan
- [ ] Verify the release workflow runs tests before creating release artifacts

Closes #21