### PR TITLE
feat: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues:
+  enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/xcrtp/xcmixin
+    about: Check the README for usage information

--- a/.github/ISSUE_TEMPLATE/example.md
+++ b/.github/ISSUE_TEMPLATE/example.md
@@ -1,0 +1,22 @@
+---
+name: Example
+about: Add a new example to demonstrate xcmixin usage
+title: 'Example: '
+labels: example
+---
+
+## Description
+
+<!-- Describe what this example demonstrates and what functionality it showcases -->
+
+-
+
+## Reference
+
+<!-- Provide reference implementation or links if applicable -->
+
+## Acceptance Criteria
+
+- [ ] Create `examples/` example file
+- [ ] Example compiles and runs
+- [ ] Demonstrate


### PR DESCRIPTION
## Summary

- Add GitHub issue templates for creating new examples
- Include example template with description, reference, and acceptance criteria
- Configure to disable blank issues

## Test plan

- [ ] Verify templates appear correctly when creating new issues